### PR TITLE
Separate middleware context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,20 @@ export class MajoContext {
   }
 
   /**
+   * Filter files
+   * @param fn Filter handler
+   */
+  filter(fn: FilterHandler) {
+    for (const relativePath in this.files) {
+      if (!fn(relativePath, this.files[relativePath])) {
+        delete this.files[relativePath]
+      }
+    }
+
+    return this
+  }
+
+  /**
    * Delete a file
    * @param relativePath Relative path
    */
@@ -213,7 +227,19 @@ export class Majo extends MajoContext {
       fn(this)
       return this
     }
-    return this.use(fn)
+    return this.use(context => {
+      this.syncFromContext(context)
+      return fn(context)
+    })
+  }
+
+  private syncFromContext(context: MajoContext) {
+    this.files = context.files
+    this.meta = context.meta
+    this.baseDir = context.baseDir
+    this.sourcePatterns = context.sourcePatterns
+    this.dotFiles = context.dotFiles
+    this.onWrite = context.onWrite
   }
 
   /**
@@ -221,13 +247,7 @@ export class Majo extends MajoContext {
    * @param fn Filter handler
    */
   filter(fn: FilterHandler) {
-    return this.mutate(context => {
-      for (const relativePath in context.files) {
-        if (!fn(relativePath, context.files[relativePath])) {
-          delete context.files[relativePath]
-        }
-      }
-    })
+    return this.mutate(context => context.filter(fn))
   }
 
   /**
@@ -239,8 +259,7 @@ export class Majo extends MajoContext {
     if (this.processed) {
       return super.transform(relativePath, fn)
     }
-    this.use(context => context.transform(relativePath, fn))
-    return this
+    return this.mutate(context => context.transform(relativePath, fn))
   }
 
   /**
@@ -252,7 +271,7 @@ export class Majo extends MajoContext {
     if (this.processed) {
       return super.writeContents(relativePath, contents)
     }
-    return this.use(context => context.writeContents(relativePath, contents))
+    return this.mutate(context => context.writeContents(relativePath, contents))
   }
 
   /**
@@ -263,7 +282,7 @@ export class Majo extends MajoContext {
     if (this.processed) {
       return super.deleteFile(relativePath)
     }
-    return this.use(context => context.deleteFile(relativePath))
+    return this.mutate(context => context.deleteFile(relativePath))
   }
 
   /**
@@ -275,14 +294,14 @@ export class Majo extends MajoContext {
     if (this.processed) {
       return super.createFile(relativePath, file)
     }
-    return this.use(context => context.createFile(relativePath, file))
+    return this.mutate(context => context.createFile(relativePath, file))
   }
 
   rename(fromPath: string, toPath: string) {
     if (this.processed) {
       return super.rename(fromPath, toPath)
     }
-    return this.use(context => context.rename(fromPath, toPath))
+    return this.mutate(context => context.rename(fromPath, toPath))
   }
 
   /**
@@ -326,9 +345,7 @@ export class Majo extends MajoContext {
 
     await new Wares().use(this.middlewares).run(context)
 
-    this.files = context.files
-    this.meta = context.meta
-    this.onWrite = context.onWrite
+    this.syncFromContext(context)
     this.processed = true
 
     return this

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,10 +320,15 @@ export class Majo extends MajoContext {
 
     const context = new MajoContext(files, this.baseDir)
     context.meta = this.meta
+    context.sourcePatterns = this.sourcePatterns
+    context.dotFiles = this.dotFiles
+    context.onWrite = this.onWrite
 
     await new Wares().use(this.middlewares).run(context)
 
     this.files = context.files
+    this.meta = context.meta
+    this.onWrite = context.onWrite
     this.processed = true
 
     return this

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import rimraf from 'rimraf'
 import ensureDir from 'mkdirp'
 import Wares from './wares'
 
-export type Middleware = (ctx: Majo) => Promise<void> | void
+export type Middleware = (ctx: MajoContext) => Promise<unknown> | unknown
 
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
@@ -53,8 +53,7 @@ export interface DestOptions {
   clean?: boolean
 }
 
-export class Majo {
-  middlewares: Middleware[]
+export class MajoContext {
   /**
    * An object you can use across middleware to share states
    */
@@ -73,82 +72,10 @@ export class Majo {
   }
   onWrite?: OnWrite
 
-  constructor() {
-    this.middlewares = []
+  constructor(files: { [filename: string]: File } = {}, baseDir?: string) {
     this.meta = {}
-    this.files = {}
-  }
-
-  /**
-   * Find files from specific directory
-   * @param source Glob patterns
-   * @param opts
-   * @param opts.baseDir The base directory to find files
-   * @param opts.dotFiles Including dot files
-   */
-  source(patterns: string | string[], options: SourceOptions = {}) {
-    const { baseDir = '.', dotFiles = true, onWrite } = options
-    this.baseDir = path.resolve(baseDir)
-    this.sourcePatterns = Array.isArray(patterns) ? patterns : [patterns]
-    this.dotFiles = dotFiles
-    this.onWrite = onWrite
-    return this
-  }
-
-  /**
-   * Use a middleware
-   */
-  use(middleware: Middleware) {
-    this.middlewares.push(middleware)
-    return this
-  }
-
-  /**
-   * Process middlewares against files
-   */
-  async process() {
-    if (!this.sourcePatterns || !this.baseDir) {
-      throw new Error(`[majo] You need to call .source first`)
-    }
-
-    const allEntries = await glob(this.sourcePatterns, {
-      cwd: this.baseDir,
-      dot: this.dotFiles,
-      stats: true
-    })
-
-    await Promise.all(
-      allEntries.map(entry => {
-        const absolutePath = path.resolve(this.baseDir as string, entry.path)
-        return readFile(absolutePath).then(contents => {
-          const file = {
-            contents,
-            stats: entry.stats as fs.Stats,
-            path: absolutePath
-          }
-          // Use relative path as key
-          this.files[entry.path] = file
-        })
-      })
-    )
-
-    await new Wares().use(this.middlewares).run(this)
-
-    return this
-  }
-
-  /**
-   * Filter files
-   * @param fn Filter handler
-   */
-  filter(fn: FilterHandler) {
-    return this.use(context => {
-      for (const relativePath in context.files) {
-        if (!fn(relativePath, context.files[relativePath])) {
-          delete context.files[relativePath]
-        }
-      }
-    })
+    this.files = files
+    this.baseDir = baseDir
   }
 
   /**
@@ -156,42 +83,18 @@ export class Majo {
    * @param relativePath Relative path
    * @param fn Transform handler
    */
-  async transform(relativePath: string, fn: TransformHandler) {
+  transform(relativePath: string, fn: TransformHandler): this | Promise<this> {
     const contents = this.files[relativePath].contents.toString()
-    const newContents = await fn(contents)
-    this.files[relativePath].contents = Buffer.from(newContents)
-  }
-
-  /**
-   * Run middlewares and write processed files to disk
-   * @param dest Target directory
-   * @param opts
-   * @param opts.baseDir Base directory to resolve target directory
-   * @param opts.clean Clean directory before writing
-   */
-  async dest(dest: string, options: DestOptions = {}) {
-    const { baseDir = '.', clean = false } = options
-    const destPath = path.resolve(baseDir, dest)
-    await this.process()
-
-    if (clean) {
-      await remove(destPath)
+    const newContents = fn(contents)
+    if (typeof newContents === 'string') {
+      this.files[relativePath].contents = Buffer.from(newContents)
+      return this
     }
 
-    await Promise.all(
-      Object.keys(this.files).map(filename => {
-        const { contents } = this.files[filename]
-        const target = path.join(destPath, filename)
-        if (this.onWrite) {
-          this.onWrite(filename, target)
-        }
-        return ensureDir(path.dirname(target)).then(() =>
-          writeFile(target, contents)
-        )
-      })
-    )
-
-    return this
+    return newContents.then(contents => {
+      this.files[relativePath].contents = Buffer.from(contents)
+      return this
+    })
   }
 
   /**
@@ -259,12 +162,204 @@ export class Majo {
       return this
     }
     const file = this.files[fromPath]
-    this.createFile(toPath, {
+    this.files[toPath] = {
       path: path.resolve(this.baseDir, toPath),
       stats: file.stats,
       contents: file.contents
+    }
+    delete this.files[fromPath]
+    return this
+  }
+}
+
+export class Majo extends MajoContext {
+  middlewares: Middleware[]
+  private processed: boolean
+
+  constructor() {
+    super()
+    this.middlewares = []
+    this.processed = false
+  }
+
+  /**
+   * Find files from specific directory
+   * @param source Glob patterns
+   * @param opts
+   * @param opts.baseDir The base directory to find files
+   * @param opts.dotFiles Including dot files
+   */
+  source(patterns: string | string[], options: SourceOptions = {}) {
+    const { baseDir = '.', dotFiles = true, onWrite } = options
+    this.baseDir = path.resolve(baseDir)
+    this.sourcePatterns = Array.isArray(patterns) ? patterns : [patterns]
+    this.dotFiles = dotFiles
+    this.onWrite = onWrite
+    this.files = {}
+    this.processed = false
+    return this
+  }
+
+  /**
+   * Use a middleware
+   */
+  use(middleware: Middleware) {
+    this.middlewares.push(middleware)
+    return this
+  }
+
+  private mutate(fn: (context: MajoContext) => unknown) {
+    if (this.processed) {
+      fn(this)
+      return this
+    }
+    return this.use(fn)
+  }
+
+  /**
+   * Filter files
+   * @param fn Filter handler
+   */
+  filter(fn: FilterHandler) {
+    return this.mutate(context => {
+      for (const relativePath in context.files) {
+        if (!fn(relativePath, context.files[relativePath])) {
+          delete context.files[relativePath]
+        }
+      }
     })
-    this.deleteFile(fromPath)
+  }
+
+  /**
+   * Transform file at given path
+   * @param relativePath Relative path
+   * @param fn Transform handler
+   */
+  transform(relativePath: string, fn: TransformHandler) {
+    if (this.processed) {
+      return super.transform(relativePath, fn)
+    }
+    this.use(context => context.transform(relativePath, fn))
+    return this
+  }
+
+  /**
+   * Write contents to specific file
+   * @param relativePath Relative path
+   * @param string File content as a UTF-8 string
+   */
+  writeContents(relativePath: string, contents: string) {
+    if (this.processed) {
+      return super.writeContents(relativePath, contents)
+    }
+    return this.use(context => context.writeContents(relativePath, contents))
+  }
+
+  /**
+   * Delete a file
+   * @param relativePath Relative path
+   */
+  deleteFile(relativePath: string) {
+    if (this.processed) {
+      return super.deleteFile(relativePath)
+    }
+    return this.use(context => context.deleteFile(relativePath))
+  }
+
+  /**
+   * Create a new file
+   * @param relativePath Relative path
+   * @param file
+   */
+  createFile(relativePath: string, file: File) {
+    if (this.processed) {
+      return super.createFile(relativePath, file)
+    }
+    return this.use(context => context.createFile(relativePath, file))
+  }
+
+  rename(fromPath: string, toPath: string) {
+    if (this.processed) {
+      return super.rename(fromPath, toPath)
+    }
+    return this.use(context => context.rename(fromPath, toPath))
+  }
+
+  /**
+   * Process middlewares against files
+   */
+  async process() {
+    if (!this.sourcePatterns || !this.baseDir) {
+      throw new Error(`[majo] You need to call .source first`)
+    }
+
+    const allEntries = await glob(this.sourcePatterns, {
+      cwd: this.baseDir,
+      dot: this.dotFiles,
+      stats: true
+    })
+
+    const files: {
+      [filename: string]: File
+    } = {}
+
+    await Promise.all(
+      allEntries.map(entry => {
+        const absolutePath = path.resolve(this.baseDir as string, entry.path)
+        return readFile(absolutePath).then(contents => {
+          const file = {
+            contents,
+            stats: entry.stats as fs.Stats,
+            path: absolutePath
+          }
+          // Use relative path as key
+          files[entry.path] = file
+        })
+      })
+    )
+
+    const context = new MajoContext(files, this.baseDir)
+    context.meta = this.meta
+
+    await new Wares().use(this.middlewares).run(context)
+
+    this.files = context.files
+    this.processed = true
+
+    return this
+  }
+
+  /**
+   * Run middlewares and write processed files to disk
+   * @param dest Target directory
+   * @param opts
+   * @param opts.baseDir Base directory to resolve target directory
+   * @param opts.clean Clean directory before writing
+   */
+  async dest(dest: string, options: DestOptions = {}) {
+    const { baseDir = '.', clean = false } = options
+    const destPath = path.resolve(baseDir, dest)
+    if (!this.processed) {
+      await this.process()
+    }
+
+    if (clean) {
+      await remove(destPath)
+    }
+
+    await Promise.all(
+      Object.keys(this.files).map(filename => {
+        const { contents } = this.files[filename]
+        const target = path.join(destPath, filename)
+        if (this.onWrite) {
+          this.onWrite(filename, target)
+        }
+        return ensureDir(path.dirname(target)).then(() =>
+          writeFile(target, contents)
+        )
+      })
+    )
+
     return this
   }
 }

--- a/src/wares.ts
+++ b/src/wares.ts
@@ -1,4 +1,4 @@
-import { Majo, Middleware } from './'
+import { MajoContext, Middleware } from './'
 
 export default class Wares {
   middlewares: Middleware[]
@@ -13,9 +13,11 @@ export default class Wares {
     return this
   }
 
-  run(context: Majo) {
-    return this.middlewares.reduce((current, next) => {
-      return current.then(() => Promise.resolve(next(context)))
+  run(context: MajoContext): Promise<void> {
+    return this.middlewares.reduce((current: Promise<void>, next) => {
+      return current.then(() =>
+        Promise.resolve(next(context)).then(() => undefined)
+      )
     }, Promise.resolve())
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,6 +41,36 @@ test('middleware context is separate from majo instance', async () => {
   await stream.process()
 })
 
+test('middleware context keeps source state', async () => {
+  const baseDir = path.join(__dirname, 'fixture/source')
+  const onWrite = jest.fn()
+  const nextOnWrite = jest.fn()
+  const stream = majo().source('**', {
+    baseDir,
+    dotFiles: false,
+    onWrite
+  })
+
+  stream.use(context => {
+    expect(context.baseDir).toBe(path.resolve(baseDir))
+    expect(context.sourcePatterns).toEqual(['**'])
+    expect(context.dotFiles).toBe(false)
+    expect(context.onWrite).toBe(onWrite)
+
+    context.meta = { changed: true }
+    context.onWrite = nextOnWrite
+  })
+
+  await stream.process()
+
+  expect(stream.meta).toEqual({ changed: true })
+
+  await stream.dest('./output/context-state', { baseDir: __dirname })
+
+  expect(onWrite).not.toHaveBeenCalled()
+  expect(nextOnWrite).toHaveBeenCalled()
+})
+
 test('file operations can be called before processing', async () => {
   const baseDir = path.join(__dirname, 'fixture/source')
   const stream = majo().source('**', {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
-import { majo, glob, remove } from '../src'
+import fs from 'fs'
+import { Majo, majo, glob, remove } from '../src'
 
 test('main', async () => {
   const outputDir = path.join(__dirname, 'output/main')
@@ -23,6 +24,43 @@ test('middleware', async () => {
   await stream.process()
 
   expect(stream.fileContents('tmp.js')).toMatch(`const a = () => 'aaa'`)
+})
+
+test('middleware context is separate from majo instance', async () => {
+  const stream = majo().source('**', {
+    baseDir: path.join(__dirname, 'fixture/source')
+  })
+
+  stream.use(context => {
+    expect(context).not.toBe(stream)
+    expect(context).not.toBeInstanceOf(Majo)
+    expect(context).not.toHaveProperty('source')
+    expect(context.fileList).toContain('tmp.js')
+  })
+
+  await stream.process()
+})
+
+test('file operations can be called before processing', async () => {
+  const baseDir = path.join(__dirname, 'fixture/source')
+  const stream = majo().source('**', {
+    baseDir
+  })
+
+  stream.transform('tmp.js', contents => contents.replace(`'a'`, `'bbb'`))
+  stream.writeContents('should-filter.js', 'module.exports = true\n')
+  stream.createFile('created.txt', {
+    path: path.join(baseDir, 'created.txt'),
+    stats: fs.statSync(path.join(baseDir, 'tmp.js')),
+    contents: Buffer.from('created')
+  })
+  stream.deleteFile('should-filter.js')
+
+  await stream.process()
+
+  expect(stream.fileContents('tmp.js')).toMatch(`const a = () => 'bbb'`)
+  expect(stream.fileContents('created.txt')).toBe('created')
+  expect(stream.fileList).not.toContain('should-filter.js')
 })
 
 test('filter', async () => {
@@ -62,4 +100,44 @@ test('rename', async () => {
   await stream.process()
 
   expect(stream.fileList).toEqual(['b/c.txt'])
+})
+
+test('rename can be called before writing to dest', async () => {
+  const outputDir = path.join(__dirname, 'output/rename')
+  await remove(outputDir)
+
+  const stream = await majo()
+    .source('**/*', { baseDir: path.join(__dirname, 'fixture/rename') })
+    .rename('a.txt', 'b/c.txt')
+    .dest('./output/rename', { baseDir: __dirname })
+
+  expect(stream.fileList).toEqual(['b/c.txt'])
+  expect(await glob('**/*', { cwd: outputDir })).toEqual(['b/c.txt'])
+})
+
+test('file operations can be called after processing', async () => {
+  const outputDir = path.join(__dirname, 'output/post-process')
+  await remove(outputDir)
+
+  const stream = majo().source('**/*', {
+    baseDir: path.join(__dirname, 'fixture/rename')
+  })
+
+  await stream.process()
+
+  stream.createFile('b.txt', {
+    ...stream.file('a.txt'),
+    path: path.join(__dirname, 'fixture/rename/b.txt'),
+    contents: Buffer.from('b')
+  })
+  stream.rename('a.txt', 'c.txt')
+
+  expect(stream.fileList).toEqual(['b.txt', 'c.txt'])
+  expect(stream.fileContents('b.txt')).toBe('b')
+
+  await stream.dest('./output/post-process', { baseDir: __dirname })
+
+  expect(
+    await glob('**/*', { cwd: outputDir }).then(result => result.sort())
+  ).toEqual(['b.txt', 'c.txt'])
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,6 +71,39 @@ test('middleware context keeps source state', async () => {
   expect(nextOnWrite).toHaveBeenCalled()
 })
 
+test('middleware context supports filtering files', async () => {
+  const stream = majo().source('**', {
+    baseDir: path.join(__dirname, 'fixture/source')
+  })
+
+  stream.use(context => {
+    context.filter(filepath => filepath !== 'should-filter.js')
+  })
+
+  await stream.process()
+
+  expect(stream.fileList).toContain('tmp.js')
+  expect(stream.fileList).not.toContain('should-filter.js')
+})
+
+test('queued file operations can read reassigned stream meta', async () => {
+  const stream = majo().source('**', {
+    baseDir: path.join(__dirname, 'fixture/source')
+  })
+
+  stream.use(context => {
+    context.meta = { keepFilterFixture: true }
+  })
+
+  stream.filter(filepath => {
+    return filepath !== 'should-filter.js' || stream.meta.keepFilterFixture
+  })
+
+  await stream.process()
+
+  expect(stream.fileList).toContain('should-filter.js')
+})
+
 test('file operations can be called before processing', async () => {
   const baseDir = path.join(__dirname, 'fixture/source')
   const stream = majo().source('**', {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -48,6 +48,7 @@ test('file operations can be called before processing', async () => {
   })
 
   stream.transform('tmp.js', contents => contents.replace(`'a'`, `'bbb'`))
+  stream.rename('tmp.js', 'renamed/tmp.js')
   stream.writeContents('should-filter.js', 'module.exports = true\n')
   stream.createFile('created.txt', {
     path: path.join(baseDir, 'created.txt'),
@@ -58,8 +59,9 @@ test('file operations can be called before processing', async () => {
 
   await stream.process()
 
-  expect(stream.fileContents('tmp.js')).toMatch(`const a = () => 'bbb'`)
+  expect(stream.fileContents('renamed/tmp.js')).toMatch(`const a = () => 'bbb'`)
   expect(stream.fileContents('created.txt')).toBe('created')
+  expect(stream.fileList).not.toContain('tmp.js')
   expect(stream.fileList).not.toContain('should-filter.js')
 })
 


### PR DESCRIPTION
Fixes #12.

This splits the middleware-facing file API into `MajoContext`, while keeping `Majo` chainable for direct use.

Direct calls such as `.rename()` and `.createFile()` now queue when they are made before files are loaded, then run during `process()` or `dest()`. After `process()` has completed, the same helpers still apply immediately to the current file map.

Regression coverage added for:

- middleware receiving a separate context
- middleware context preserving source state and write hooks
- middleware `ctx.filter(...)` compatibility and queued operations reading reassigned `stream.meta`
- direct file operations before processing
- direct rename before `dest()`
- direct file operations after processing

Verified locally:

```text
npm test -- --runInBand
npm run build
```

The added regression tests also fail on current master, including the middleware context and queued file-operation cases.

The Vercel check is blocked on EGOIST team deployment authorization for forked PRs. The local test and build path passes.

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#12: Separate the majo instance and middleware context](https://oss.issuehunt.io/repos/89489924/issues/12)
---
</details>
<!-- /Issuehunt content-->


